### PR TITLE
feat: konami command & multiple bullet

### DIFF
--- a/1_2d_game/src/main.cpp
+++ b/1_2d_game/src/main.cpp
@@ -147,7 +147,7 @@ struct PlayerBullet : Updatable, Drawable, Collidable {
         glm::fvec2 pos = currentPosition - cameraOffset;
         float width = 0.015f;
         float height = 0.04f;
-        float zDepth = -0.1f;
+        float zDepth = 0.0f;
 
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE);
@@ -242,6 +242,7 @@ struct Player : Updatable, Drawable, Collidable {
     bool isDying = false;
     int deathStartTime = 0;
     std::vector<PlayerFragment> fragments;
+    int bulletCount = 3; // Number of bullets to fire at once
 
     Player(glm::fvec2 initialPosition) : currentPosition(initialPosition) {}
     ~Player() override {}
@@ -853,7 +854,25 @@ bool Player::update(int currentTime, GameState &gameState) {
     }
 
     if (currentTime >= this->coolTime && this->isBullet) {
-        gameState.playerBulletObjects.emplace_back(this->currentPosition, 0.003f, currentTime);
+        // Fire bullets dynamically based on bulletCount
+        float spacing = 0.03f; // Base spacing between bullets
+        float totalWidth = spacing * static_cast<float>(bulletCount - 1);
+        float startX = -totalWidth / 2.0f;
+        float yForwardOffset = 0.04f; // How far forward the center bullet is
+
+        for (int i = 0; i < bulletCount; ++i) {
+            float xOffset = startX + (spacing * static_cast<float>(i));
+            // Calculate Y offset - center bullets are more forward
+            float centerDistance =
+                std::abs(static_cast<float>(i) - static_cast<float>(bulletCount - 1) / 2.0f);
+            float normalizedDistance =
+                centerDistance / (static_cast<float>(bulletCount - 1) / 2.0f);
+            float yOffset = yForwardOffset * (1.0f - normalizedDistance);
+
+            gameState.playerBulletObjects.emplace_back(
+                this->currentPosition + glm::fvec2(xOffset, yOffset), 0.003f, currentTime);
+        }
+
         this->isBullet = false;
         this->coolTime = currentTime + 100;
     }
@@ -1151,7 +1170,7 @@ void BossHealthBar::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
     glPopMatrix();
 }
 
-GameState gameState(5, 500);
+GameState gameState(5, 1000);
 
 // Konami Command: up, up, down, down, left, right, left, right, B, A
 // This command is widely known in gaming culture for granting special
@@ -1166,6 +1185,9 @@ CommandExecutor commandExecutor({'w', 'w', 's', 's', 'a', 'd', 'a', 'd', 'b', 'a
                                     gameState.playerObject.isInvincible = true;
                                     gameState.playerObject.invincibilityEndTime =
                                         currentTime + 5000; // 5 seconds
+
+                                    // Upgrade to 5 bullets
+                                    gameState.playerObject.bulletCount = 5;
 
                                     std::cout << "Konami Command Activated! Power up!" << '\n';
                                 });

--- a/1_2d_game/src/main.cpp
+++ b/1_2d_game/src/main.cpp
@@ -746,7 +746,7 @@ struct GameState {
           bossObject(glm::fvec2(0.0f, 0.6f)), bossHealthBarObject(glm::fvec2(0.0f, 0.0f)),
           heartsObject(glm::fvec2(0.0f, 0.0f)) {}
 
-    const int MAX_PLAYER_HEALTH;
+    int MAX_PLAYER_HEALTH;
     const int MAX_BOSS_HEALTH;
     int playerHealth;
     int bossHealth;
@@ -760,6 +760,60 @@ struct GameState {
 
     std::vector<PlayerBullet> playerBulletObjects;
     std::vector<EnemyBullet> enemyBulletObjects;
+};
+
+struct CommandExecutor : Updatable {
+    std::vector<char> commandSequence;
+    std::size_t currentIndex = 0;
+    bool previousKeyStates[256] = {false};
+    bool commandUsed = false;
+    std::function<void(GameState &)> onActivate;
+
+    CommandExecutor(std::vector<char> sequence, std::function<void(GameState &)> activateFunc)
+        : commandSequence(std::move(sequence)), onActivate(std::move(activateFunc)) {}
+    ~CommandExecutor() override = default;
+
+    bool update(int currentTime, GameState &gameState) override {
+        // Check for key press events (rising edge detection)
+        for (int i = 0; i < 256; i++) {
+            if (keyStates[i] && !previousKeyStates[i]) {
+                // Key was just pressed
+                handleKeyPress(static_cast<char>(i), gameState);
+            }
+            previousKeyStates[i] = keyStates[i];
+        }
+        return false;
+    }
+
+    void handleKeyPress(char key, GameState &gameState) {
+        if (commandUsed)
+            return;
+
+        // Check if the pressed key matches the current position in the sequence
+        if (currentIndex < commandSequence.size() && key == commandSequence[currentIndex]) {
+            currentIndex++;
+
+            // Check if the entire sequence has been completed
+            if (currentIndex >= commandSequence.size()) {
+                activateCommand(gameState);
+            }
+        } else {
+            // Reset if wrong key pressed, but check if this key could start the sequence
+            if (!commandSequence.empty() && key == commandSequence[0]) {
+                currentIndex = 1;
+            } else {
+                currentIndex = 0;
+            }
+        }
+    }
+
+    void activateCommand(GameState &gameState) {
+        if (commandUsed)
+            return;
+
+        commandUsed = true;
+        onActivate(gameState);
+    }
 };
 
 bool Player::update(int currentTime, GameState &gameState) {
@@ -813,7 +867,7 @@ bool EnemyBullet::update(int currentTime, GameState &gameState) {
     // Don't damage player if boss is already dying
     if (!gameState.bossObject.isDying && !gameState.playerObject.isInvincible &&
         detectCollision(*this, gameState.playerObject)) {
-        gameState.playerHealth -= 1;
+        gameState.playerHealth -= 0;
         gameState.playerObject.takeDamage(currentTime);
         startCameraShake(currentTime);
         if (gameState.playerHealth < 0)
@@ -1099,6 +1153,23 @@ void BossHealthBar::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
 
 GameState gameState(5, 500);
 
+// Konami Command: up, up, down, down, left, right, left, right, B, A
+// This command is widely known in gaming culture for granting special
+CommandExecutor commandExecutor({'w', 'w', 's', 's', 'a', 'd', 'a', 'd', 'b', 'a'},
+                                [](GameState &gameState) {
+                                    // Activate Konami command effects
+                                    gameState.MAX_PLAYER_HEALTH = 10;
+                                    gameState.playerHealth = 10;
+
+                                    // Grant 5 seconds of invincibility
+                                    int currentTime = glutGet(GLUT_ELAPSED_TIME);
+                                    gameState.playerObject.isInvincible = true;
+                                    gameState.playerObject.invincibilityEndTime =
+                                        currentTime + 5000; // 5 seconds
+
+                                    std::cout << "Konami Command Activated! Power up!" << '\n';
+                                });
+
 void keyboardDown(unsigned char key, int /*x*/, int /*y*/) { keyStates[key] = true; }
 void keyboardUp(unsigned char key, int /*x*/, int /*y*/) { keyStates[key] = false; }
 
@@ -1239,6 +1310,7 @@ void timer(int) {
     gameState.backgroundObject.update(now, gameState);
     gameState.playerObject.update(now, gameState);
     gameState.bossObject.update(now, gameState);
+    commandExecutor.update(now, gameState);
 
     glutTimerFunc(16, timer, 0);
 }

--- a/1_2d_game/src/main.cpp
+++ b/1_2d_game/src/main.cpp
@@ -886,7 +886,7 @@ bool EnemyBullet::update(int currentTime, GameState &gameState) {
     // Don't damage player if boss is already dying
     if (!gameState.bossObject.isDying && !gameState.playerObject.isInvincible &&
         detectCollision(*this, gameState.playerObject)) {
-        gameState.playerHealth -= 0;
+        gameState.playerHealth -= 1;
         gameState.playerObject.takeDamage(currentTime);
         startCameraShake(currentTime);
         if (gameState.playerHealth < 0)


### PR DESCRIPTION
* 플레이어 총알이 한번에 3개 나가게 변경합니다.
* 대신 보스 체력을 2배 올린 1000으로 변경합니다.
* 코나미 커맨드를 추가합니다.
  * `wwssadadba`로 활성화합니다.
  * 체력이 모두 회복되고 10으로 늘어납니다.
  * 5초의 무적 시간이 부여됩니다.
  * 발사하는 총알이 5개로 늘어납니다.