### PR TITLE
feat: camera

### DIFF
--- a/2_2d_animation/src/Background.cpp
+++ b/2_2d_animation/src/Background.cpp
@@ -65,17 +65,17 @@ static void drawWorldBorder() {
     glLineWidth(5.0f);
 
     glBegin(GL_LINES);
-        glVertex2f(-2.0f, -2.0f);
-        glVertex2f(-2.0f, 2.0f);
+    glVertex2f(-2.0f, -2.0f);
+    glVertex2f(-2.0f, 2.0f);
 
-        glVertex2f(-2.0f, 2.0f);
-        glVertex2f(2.0f, 2.0f);
+    glVertex2f(-2.0f, 2.0f);
+    glVertex2f(2.0f, 2.0f);
 
-        glVertex2f(2.0f, 2.0f);
-        glVertex2f(2.0f, -2.0f);
+    glVertex2f(2.0f, 2.0f);
+    glVertex2f(2.0f, -2.0f);
 
-        glVertex2f(2.0f, -2.0f);
-        glVertex2f(-2.0f, -2.0f);
+    glVertex2f(2.0f, -2.0f);
+    glVertex2f(-2.0f, -2.0f);
     glEnd();
 }
 

--- a/2_2d_animation/src/Background.cpp
+++ b/2_2d_animation/src/Background.cpp
@@ -5,9 +5,9 @@ Star::Star(glm::fvec2 pos, float spd, float sz, float br)
 
 bool Star::update(int deltaTime, GameState & /*gameState*/) {
     position.y -= speed * static_cast<float>(deltaTime);
-    if (position.y < -1.1f) {
-        position.y = 1.1f;
-        position.x = -1.0f + dist(gen) * 2.0f;
+    if (position.y < -2.2f) {
+        position.y = 2.2f;
+        position.x = -2.0f + dist(gen) * 4.0f;
     }
     return false;
 }
@@ -33,11 +33,11 @@ void Star::draw(const GameState &) {
 Background::Background() : lastUpdateTime(0) { initializeStars(); }
 
 void Background::initializeStars() {
-    const int NUM_STARS = 60;
+    const int NUM_STARS = 100;
     stars.reserve(NUM_STARS);
     for (int i = 0; i < NUM_STARS; ++i) {
-        float x = -1.0f + dist(gen) * 2.0f;
-        float y = -1.0f + dist(gen) * 2.0f;
+        float x = -2.0f + dist(gen) * 4.0f;
+        float y = -2.0f + dist(gen) * 4.0f;
         float speed = 0.0008f + dist(gen) * 0.001f;
         float size = 1.0f + dist(gen) * 3.0f;
         float brightness = 0.3f + dist(gen) * 0.7f;
@@ -60,6 +60,25 @@ bool Background::update(int currentTime, GameState &gameState) {
     return false;
 }
 
+static void drawWorldBorder() {
+    glColor3f(1.0f, 1.0f, 1.0f);
+    glLineWidth(5.0f);
+
+    glBegin(GL_LINES);
+        glVertex2f(-2.0f, -2.0f);
+        glVertex2f(-2.0f, 2.0f);
+
+        glVertex2f(-2.0f, 2.0f);
+        glVertex2f(2.0f, 2.0f);
+
+        glVertex2f(2.0f, 2.0f);
+        glVertex2f(2.0f, -2.0f);
+
+        glVertex2f(2.0f, -2.0f);
+        glVertex2f(-2.0f, -2.0f);
+    glEnd();
+}
+
 void Background::draw(const GameState &gameState) {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -69,6 +88,5 @@ void Background::draw(const GameState &gameState) {
         star.draw(gameState);
     }
 
-    glDisable(GL_POINT_SMOOTH);
-    glDisable(GL_BLEND);
+    drawWorldBorder();
 }

--- a/2_2d_animation/src/Background.cpp
+++ b/2_2d_animation/src/Background.cpp
@@ -12,9 +12,7 @@ bool Star::update(int deltaTime, GameState & /*gameState*/) {
     return false;
 }
 
-void Star::draw(glm::fvec2 cameraOffset, const GameState &) {
-    const glm::fvec2 VIEW_POS = position - cameraOffset;
-
+void Star::draw(const GameState &) {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
@@ -22,7 +20,7 @@ void Star::draw(glm::fvec2 cameraOffset, const GameState &) {
     glPointSize(size);
 
     glPushMatrix();
-    glTranslatef(VIEW_POS.x, VIEW_POS.y, -0.99f);
+    glTranslatef(position.x, position.y, -0.99f);
 
     glBegin(GL_POINTS);
     glVertex3f(0.0f, 0.0f, 0.0f);
@@ -62,13 +60,13 @@ bool Background::update(int currentTime, GameState &gameState) {
     return false;
 }
 
-void Background::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
+void Background::draw(const GameState &gameState) {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glEnable(GL_POINT_SMOOTH);
 
     for (auto &star : stars) {
-        star.draw(cameraOffset, gameState);
+        star.draw(gameState);
     }
 
     glDisable(GL_POINT_SMOOTH);

--- a/2_2d_animation/src/Boss.cpp
+++ b/2_2d_animation/src/Boss.cpp
@@ -15,14 +15,12 @@ bool BossFragment::update(int deltaTime, GameState &) {
     return alpha <= 0.0f || size <= 0.001f;
 }
 
-void BossFragment::draw(glm::fvec2 cameraOffset, const GameState &) {
-    const glm::fvec2 VIEW_POS = position - cameraOffset;
-
+void BossFragment::draw(const GameState &) {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE); // 기존 가산 블렌딩 유지
 
     glPushMatrix();
-    glTranslatef(VIEW_POS.x, VIEW_POS.y, 0.0f); // 위치
+    glTranslatef(position.x, position.y, 0.0f); // 위치
     glRotatef(rotation, 0.0f, 0.0f, 1.0f);      // 회전
     glScalef(size, size, 1.0f);                 // 크기 (행렬로 처리)
 
@@ -115,7 +113,7 @@ void BossArm::drawJoint(float size) {
     glPopMatrix();
 }
 
-void BossArm::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
+void BossArm::draw(const GameState &gameState) {
     float t = static_cast<float>(glutGet(GLUT_ELAPSED_TIME)) * 0.001f;
     update(t);
 
@@ -265,15 +263,14 @@ void Boss::drawUnitSpikeTri(float rOuter, float rInner, float z, const glm::vec4
 }
 
 // 메인 드로우
-void Boss::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
-    const glm::fvec2 VIEW_POS = currentPosition - cameraOffset;
+void Boss::draw(const GameState &gameState) {
     const float SIZE = 0.15f; // 전체 스케일(월드 단위)
     const float T = static_cast<float>(glutGet(GLUT_ELAPSED_TIME)) * 0.001f;
 
     if (isDying) {
         // 파편
         for (auto &fragment : fragments) {
-            fragment.draw(cameraOffset, gameState);
+            fragment.draw(gameState);
         }
 
         // 폭발
@@ -287,7 +284,7 @@ void Boss::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
             const float A = 1.0f - DT * 0.67f;                      // 느리게 페이드
 
             glPushMatrix();
-            glTranslatef(VIEW_POS.x, VIEW_POS.y, 0.f);
+            glTranslatef(currentPosition.x, currentPosition.y, 0.f);
             glScalef(EXPLOSION_SIZE, EXPLOSION_SIZE, 1.f);
             drawUnitCircleFan(
                 /*seg=*/20, /*z=*/0.0f,
@@ -305,7 +302,7 @@ void Boss::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
 
     // 모델 행렬
     glPushMatrix();
-    glTranslatef(VIEW_POS.x, VIEW_POS.y, 0.f);
+    glTranslatef(currentPosition.x, currentPosition.y, 0.f);
     // glRotatef(angle, 0,0,1)
     glScalef(SIZE, SIZE, 1.f);
 
@@ -358,8 +355,8 @@ void Boss::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
     }
 
     // 좌우 팔
-    leftArm.draw(cameraOffset, gameState);
-    rightArm.draw(cameraOffset, gameState);
+    leftArm.draw(gameState);
+    rightArm.draw(gameState);
 
     glPopMatrix(); // 모델 행렬 끝
     glDisable(GL_BLEND);

--- a/2_2d_animation/src/Boss.cpp
+++ b/2_2d_animation/src/Boss.cpp
@@ -140,7 +140,7 @@ void BossArm::draw(const GameState &gameState) {
 
 Boss::Boss(glm::fvec2 initialPosition, int id)
     : currentPosition(initialPosition), currentMove(idleBossMove(initialPosition, 0)),
-      leftArm(true, id), rightArm(false, id) {}
+      leftArm(true, id), rightArm(false, id), bossId(id) {}
 
 bool Boss::update(int currentTime, GameState &gameState) {
     if (isDying) {
@@ -282,7 +282,7 @@ void Boss::draw(const GameState &gameState) {
 
             const float EXPLOSION_SIZE = 0.3f * (1.0f + DT * 2.0f); // 느리게 팽창
             const float A = 1.0f - DT * 0.67f;                      // 느리게 페이드
-
+            
             glPushMatrix();
             glTranslatef(currentPosition.x, currentPosition.y, 0.f);
             glScalef(EXPLOSION_SIZE, EXPLOSION_SIZE, 1.f);
@@ -323,9 +323,14 @@ void Boss::draw(const GameState &gameState) {
         glPushMatrix();
         glRotatef((360.f / 6.f) * static_cast<float>(i), 0.f, 0.f, 1.f);
         drawUnitSpikeTri(
-            /*rOuter=*/1.3f, /*rInner=*/0.8f, /*z=*/0.02f,
-            /*innerRGBA*/ glm::vec4(0.6f, 0.1f, 1.0f, 0.9f),
-            /*tipRGBA  */ glm::vec4(0.2f, 0.0f, 0.4f, 0.6f));
+            1.3f, // rOuter
+            0.8f, // rInner
+            0.02f, // z
+            bossId == 1 ? glm::vec4(0.6f, 0.1f, 1.0f, 0.9f) // innerRGBA
+                        : glm::vec4(0.3f, 0.4f, 0.8f, 0.9f),
+            bossId == 1 ? glm::vec4(0.2f, 0.0f, 0.4f, 0.6f) // tipRGBA
+                        : glm::vec4(0.3f, 0.4f, 0.8f, 0.9f)
+        );
         glPopMatrix();
     }
     glPopMatrix();

--- a/2_2d_animation/src/Boss.cpp
+++ b/2_2d_animation/src/Boss.cpp
@@ -282,7 +282,7 @@ void Boss::draw(const GameState &gameState) {
 
             const float EXPLOSION_SIZE = 0.3f * (1.0f + DT * 2.0f); // 느리게 팽창
             const float A = 1.0f - DT * 0.67f;                      // 느리게 페이드
-            
+
             glPushMatrix();
             glTranslatef(currentPosition.x, currentPosition.y, 0.f);
             glScalef(EXPLOSION_SIZE, EXPLOSION_SIZE, 1.f);
@@ -322,15 +322,13 @@ void Boss::draw(const GameState &gameState) {
     for (int i = 0; i < 6; ++i) {
         glPushMatrix();
         glRotatef((360.f / 6.f) * static_cast<float>(i), 0.f, 0.f, 1.f);
-        drawUnitSpikeTri(
-            1.3f, // rOuter
-            0.8f, // rInner
-            0.02f, // z
-            bossId == 1 ? glm::vec4(0.6f, 0.1f, 1.0f, 0.9f) // innerRGBA
-                        : glm::vec4(0.3f, 0.4f, 0.8f, 0.9f),
-            bossId == 1 ? glm::vec4(0.2f, 0.0f, 0.4f, 0.6f) // tipRGBA
-                        : glm::vec4(0.3f, 0.4f, 0.8f, 0.9f)
-        );
+        drawUnitSpikeTri(1.3f,                                           // rOuter
+                         0.8f,                                           // rInner
+                         0.02f,                                          // z
+                         bossId == 1 ? glm::vec4(0.6f, 0.1f, 1.0f, 0.9f) // innerRGBA
+                                     : glm::vec4(0.3f, 0.4f, 0.8f, 0.9f),
+                         bossId == 1 ? glm::vec4(0.2f, 0.0f, 0.4f, 0.6f) // tipRGBA
+                                     : glm::vec4(0.3f, 0.4f, 0.8f, 0.9f));
         glPopMatrix();
     }
     glPopMatrix();

--- a/2_2d_animation/src/Bullet.cpp
+++ b/2_2d_animation/src/Bullet.cpp
@@ -46,7 +46,7 @@ bool EnemyBullet::update(int currentTime, GameState &gameState) {
             gameState.playerHealth = 0;
         return true;
     }
-    return abs(currentPosition.x) > 1.0f || abs(currentPosition.y) > 1.0f;
+    return abs(currentPosition.x) > 2.0f || abs(currentPosition.y) > 2.0f;
 }
 void EnemyBullet::draw(const GameState &gameState) {
     const float BASE_SCALE = 0.03f;
@@ -126,7 +126,7 @@ bool PlayerBullet::update(int currentTime, GameState &gameState) {
             gameState.bossHealth = 0;
         return true;
     }
-    return abs(currentPosition.x) > 1.0f || abs(currentPosition.y) > 1.0f;
+    return abs(currentPosition.x) > 2.0f || abs(currentPosition.y) > 2.0f;
 }
 void PlayerBullet::draw(const GameState &gameState) {
     const float WIDTH = 0.015f;

--- a/2_2d_animation/src/Bullet.cpp
+++ b/2_2d_animation/src/Bullet.cpp
@@ -48,9 +48,7 @@ bool EnemyBullet::update(int currentTime, GameState &gameState) {
     }
     return abs(currentPosition.x) > 1.0f || abs(currentPosition.y) > 1.0f;
 }
-void EnemyBullet::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
-    const glm::fvec2 VIEW_POS = currentPosition - cameraOffset;
-
+void EnemyBullet::draw(const GameState &gameState) {
     const float BASE_SCALE = 0.03f;
 
     const float T_MS = static_cast<float>(glutGet(GLUT_ELAPSED_TIME));
@@ -60,7 +58,7 @@ void EnemyBullet::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
     glPushMatrix();
-    glTranslatef(VIEW_POS.x, VIEW_POS.y, 0.0f);
+    glTranslatef(currentPosition.x, currentPosition.y, 0.0f);
     glScalef(BASE_SCALE, BASE_SCALE, 1.0f);
 
     glBegin(GL_TRIANGLE_FAN);
@@ -130,19 +128,16 @@ bool PlayerBullet::update(int currentTime, GameState &gameState) {
     }
     return abs(currentPosition.x) > 1.0f || abs(currentPosition.y) > 1.0f;
 }
-void PlayerBullet::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
+void PlayerBullet::draw(const GameState &gameState) {
     const float WIDTH = 0.015f;
     const float HEIGHT = 0.04f;
     const float Z_DEPTH = 0.0f;
-
-    const glm::fvec2 WORLD_POS = currentPosition;
-    const glm::fvec2 VIEW_POS = WORLD_POS - cameraOffset;
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
     glPushMatrix();
-    glTranslatef(VIEW_POS.x, VIEW_POS.y, 0.0f);
+    glTranslatef(currentPosition.x, currentPosition.y, 0.0f);
     glRotatef(0.0f, 0.0f, 0.0f, 1.0f);
     glScalef(WIDTH, HEIGHT, 1.0f);
 

--- a/2_2d_animation/src/BulletPattern.cpp
+++ b/2_2d_animation/src/BulletPattern.cpp
@@ -7,16 +7,16 @@ float sqrtPosFunc1(int t, float speed) {
 }
 float sqrtPosFunc2(int t, float speed) {
     float deltaX = static_cast<float>(t) * speed;
-    return -std::sqrt(3.0f * deltaX);
+    return deltaX;
 }
 
 BulletVec bossEmptyPattern(GameState &gameState, int /*currentTime*/, int bossNum) {
     switch (bossNum) {
     case 1:
-        gameState.bossObject1.coolTimePeriod = 300;
+        gameState.bossObject1.coolTimePeriod = 500;
         break;
     case 2:
-        gameState.bossObject2.coolTimePeriod = 300;
+        gameState.bossObject2.coolTimePeriod = 500;
         break;
     default:
         break;
@@ -26,10 +26,10 @@ BulletVec bossEmptyPattern(GameState &gameState, int /*currentTime*/, int bossNu
 BulletVec bossBulletPattern1(GameState &gameState, int currentTime, int bossNum) {
     switch (bossNum) {
     case 1:
-        gameState.bossObject1.coolTimePeriod = 300;
+        gameState.bossObject1.coolTimePeriod = 500;
         break;
     case 2:
-        gameState.bossObject2.coolTimePeriod = 300;
+        gameState.bossObject2.coolTimePeriod = 500;
         break;
     default:
         break;

--- a/2_2d_animation/src/HealthBar.cpp
+++ b/2_2d_animation/src/HealthBar.cpp
@@ -4,6 +4,7 @@ PlayerHealthBar::PlayerHealthBar(glm::fvec2 drawPosition) : drawPosition(drawPos
 void PlayerHealthBar::draw(const GameState &gameState) {
     glPushMatrix();
     glLoadIdentity();
+    glTranslatef(gameState.cameraBaseOffset.x, gameState.cameraBaseOffset.y, 0);
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -69,6 +70,7 @@ void BossHealthBar::draw(const GameState &gameState) {
 
     glPushMatrix();
     glLoadIdentity();
+    glTranslatef(gameState.cameraBaseOffset.x, gameState.cameraBaseOffset.y, 0);
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/2_2d_animation/src/HealthBar.cpp
+++ b/2_2d_animation/src/HealthBar.cpp
@@ -1,7 +1,7 @@
 #include "base.hpp"
 
 PlayerHealthBar::PlayerHealthBar(glm::fvec2 drawPosition) : drawPosition(drawPosition) {}
-void PlayerHealthBar::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
+void PlayerHealthBar::draw(const GameState &gameState) {
     glPushMatrix();
     glLoadIdentity();
 
@@ -56,7 +56,7 @@ void PlayerHealthBar::draw(glm::fvec2 cameraOffset, const GameState &gameState) 
 }
 
 BossHealthBar::BossHealthBar(glm::fvec2 drawPosition) : drawPosition(drawPosition) {}
-void BossHealthBar::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
+void BossHealthBar::draw(const GameState &gameState) {
     float healthPercentage =
         static_cast<float>(gameState.bossHealth) / static_cast<float>(gameState.MAX_BOSS_HEALTH);
     healthPercentage = glm::clamp(healthPercentage, 0.0f, 1.0f);

--- a/2_2d_animation/src/MovePattern.cpp
+++ b/2_2d_animation/src/MovePattern.cpp
@@ -45,7 +45,7 @@ int random2Iteration = 0;
 std::optional<BossMove> getCurrentMove(int currentTime, GameState &gameState, int bossNum) {
     std::size_t &bossMoveListCounter = (bossNum == 1) ? boss1MoveListCounter : boss2MoveListCounter;
     int &randomIteration = (bossNum == 1) ? random1Iteration : random2Iteration;
-    int randomPeriod = (bossNum == 1) ? 5000 : 3000; 
+    int randomPeriod = (bossNum == 1) ? 5000 : 3000;
     const std::vector<MoveEntry> &currentBossMoveList =
         (bossNum == 1) ? BOSS_MOVE_LIST1 : BOSS_MOVE_LIST2;
 

--- a/2_2d_animation/src/MovePattern.cpp
+++ b/2_2d_animation/src/MovePattern.cpp
@@ -15,15 +15,15 @@ MoveFn boss2Move1 = [](int currentTime, GameState &gameState) {
                     currentTime, traj1, por1);
 };
 MoveFn boss1RandomMove = [](int currentTime, GameState &gameState) {
-    float randomX = dist(gen) * 1.7f - 0.85f;
-    float randomY = dist(gen) * 0.85f;
+    float randomX = -1.8f + dist(gen) * 3.6f;
+    float randomY = -1.2f + dist(gen) * 3.9f;
 
-    return BossMove(gameState.bossObject1.currentPosition, glm::fvec2(randomX, randomY), 1000,
+    return BossMove(gameState.bossObject1.currentPosition, glm::fvec2(randomX, randomY), 2000,
                     currentTime, zeroTraj, por1);
 };
 MoveFn boss2RandomMove = [](int currentTime, GameState &gameState) {
-    float randomX = dist(gen) * 1.7f - 0.85f;
-    float randomY = dist(gen) * 0.85f;
+    float randomX = -1.3f + dist(gen) * 2.6f;
+    float randomY = -0.9f + dist(gen) * 1.8f;
 
     return BossMove(gameState.bossObject2.currentPosition, glm::fvec2(randomX, randomY), 1000,
                     currentTime, zeroTraj, por1);
@@ -45,11 +45,12 @@ int random2Iteration = 0;
 std::optional<BossMove> getCurrentMove(int currentTime, GameState &gameState, int bossNum) {
     std::size_t &bossMoveListCounter = (bossNum == 1) ? boss1MoveListCounter : boss2MoveListCounter;
     int &randomIteration = (bossNum == 1) ? random1Iteration : random2Iteration;
+    int randomPeriod = (bossNum == 1) ? 5000 : 3000; 
     const std::vector<MoveEntry> &currentBossMoveList =
         (bossNum == 1) ? BOSS_MOVE_LIST1 : BOSS_MOVE_LIST2;
 
     if (bossMoveListCounter >= currentBossMoveList.size()) {
-        if (currentTime > 11000 + randomIteration * 5000) {
+        if (currentTime > 11000 + randomIteration * randomPeriod) {
             randomIteration += 1;
             return (bossNum == 1) ? boss1RandomMove(currentTime, gameState)
                                   : boss2RandomMove(currentTime, gameState);

--- a/2_2d_animation/src/Player.cpp
+++ b/2_2d_animation/src/Player.cpp
@@ -133,17 +133,17 @@ bool Player::update(int currentTime, GameState &gameState) {
         this->isBullet = false;
         this->coolTime = currentTime + 100;
     }
-    
+
     glm::fvec2 &cbo = gameState.cameraBaseOffset;
     if (cbo.x - currentPosition.x >= 0.6) {
-        cbo.x = currentPosition.x + 0.6;
+        cbo.x = currentPosition.x + 0.6f;
     } else if (cbo.x - currentPosition.x <= -0.6) {
-        cbo.x = currentPosition.x - 0.6;
+        cbo.x = currentPosition.x - 0.6f;
     }
     if (cbo.y - currentPosition.y >= 0.6) {
-        cbo.y = currentPosition.y + 0.6;
+        cbo.y = currentPosition.y + 0.6f;
     } else if (cbo.y - currentPosition.y <= 0.2) {
-        cbo.y = currentPosition.y + 0.2;
+        cbo.y = currentPosition.y + 0.2f;
     }
 
     return false;
@@ -172,8 +172,7 @@ void Player::draw(const GameState &gameState) {
             float alpha = 1.0f - timeSinceDeath * 0.83f;
 
             // M = T(pos - camera) * S(explosionSize)
-            glm::mat4 m =
-                glm::translate(glm::mat4(1.0f), glm::vec3(currentPosition, 0.0f));
+            glm::mat4 m = glm::translate(glm::mat4(1.0f), glm::vec3(currentPosition, 0.0f));
             m = glm::scale(m, glm::vec3(explosionSize, explosionSize, 1.0f));
 
             glPushMatrix();

--- a/2_2d_animation/src/Player.cpp
+++ b/2_2d_animation/src/Player.cpp
@@ -133,6 +133,19 @@ bool Player::update(int currentTime, GameState &gameState) {
         this->isBullet = false;
         this->coolTime = currentTime + 100;
     }
+    
+    glm::fvec2 &cbo = gameState.cameraBaseOffset;
+    if (cbo.x - currentPosition.x >= 0.6) {
+        cbo.x = currentPosition.x + 0.6;
+    } else if (cbo.x - currentPosition.x <= -0.6) {
+        cbo.x = currentPosition.x - 0.6;
+    }
+    if (cbo.y - currentPosition.y >= 0.6) {
+        cbo.y = currentPosition.y + 0.6;
+    } else if (cbo.y - currentPosition.y <= 0.2) {
+        cbo.y = currentPosition.y + 0.2;
+    }
+
     return false;
 }
 
@@ -216,14 +229,14 @@ void Player::move(glm::fvec2 deltaPosition) {
     currentPosition += deltaPosition;
 
     // Clamp
-    if (currentPosition.x < -1.0f)
-        currentPosition.x = -1.0f;
-    if (currentPosition.x > 1.0f)
-        currentPosition.x = 1.0f;
-    if (currentPosition.y < -1.0f)
-        currentPosition.y = -1.0f;
-    if (currentPosition.y > 1.0f)
-        currentPosition.y = 1.0f;
+    if (currentPosition.x < -2.0f)
+        currentPosition.x = -2.0f;
+    if (currentPosition.x > 2.0f)
+        currentPosition.x = 2.0f;
+    if (currentPosition.y < -2.0f)
+        currentPosition.y = -2.0f;
+    if (currentPosition.y > 2.0f)
+        currentPosition.y = 2.0f;
 }
 void Player::takeDamage(int currentTime) {
     if (!isInvincible) {

--- a/2_2d_animation/src/Player.cpp
+++ b/2_2d_animation/src/Player.cpp
@@ -16,14 +16,12 @@ bool PlayerFragment::update(int deltaTime, GameState &) {
     return alpha <= 0.0f || size <= 0.001f;
 }
 
-void PlayerFragment::draw(glm::fvec2 cameraOffset, const GameState &) {
-    const glm::fvec2 VIEW_POS = position - cameraOffset;
-
+void PlayerFragment::draw(const GameState &) {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
     glPushMatrix();
-    glTranslatef(VIEW_POS.x, VIEW_POS.y, 0.0f);
+    glTranslatef(position.x, position.y, 0.0f);
     glRotatef(rotation, 0.0f, 0.0f, 1.0f);
     glScalef(size, size, 1.0f);
 
@@ -142,11 +140,11 @@ void Player::tryAttack() {
     if (!isDying)
         isBullet = true;
 }
-void Player::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
+void Player::draw(const GameState &gameState) {
     if (isDying) {
         // 파편은 그대로(파편 내부에서 동일한 방식으로 모델행렬 쓰는 게 이상적)
         for (auto &fragment : fragments) {
-            fragment.draw(cameraOffset, gameState);
+            fragment.draw(gameState);
         }
 
         // 폭발 효과: 원점 단위 원을 그리고 모델 행렬로 위치/스케일 적용
@@ -162,7 +160,7 @@ void Player::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
 
             // M = T(pos - camera) * S(explosionSize)
             glm::mat4 m =
-                glm::translate(glm::mat4(1.0f), glm::vec3(currentPosition - cameraOffset, 0.0f));
+                glm::translate(glm::mat4(1.0f), glm::vec3(currentPosition, 0.0f));
             m = glm::scale(m, glm::vec3(explosionSize, explosionSize, 1.0f));
 
             glPushMatrix();
@@ -189,7 +187,7 @@ void Player::draw(glm::fvec2 cameraOffset, const GameState &gameState) {
     // 우주선: drawSpaceship을 원점/단위 스케일 기준으로 호출하고,
     // 모델 행렬로 위치/회전/스케일을 적용
     // M = T(current - camera) * R_y(tiltAngle) * S(0.14)
-    glm::mat4 m = glm::translate(glm::mat4(1.0f), glm::vec3(currentPosition - cameraOffset, 0.0f));
+    glm::mat4 m = glm::translate(glm::mat4(1.0f), glm::vec3(currentPosition, 0.0f));
     m = glm::rotate(m, glm::radians(tiltAngle), glm::vec3(0.0f, 1.0f, 0.0f));
     m = glm::scale(m, glm::vec3(0.14f, 0.14f, 0.14f));
 

--- a/2_2d_animation/src/TrailParticle.cpp
+++ b/2_2d_animation/src/TrailParticle.cpp
@@ -16,14 +16,12 @@ bool TrailParticle::update(int currentTime, GameState &) {
     return alpha <= 0.0f || size <= 0.001f || deltaTime > 2000; // Last up to 2 seconds
 }
 
-void TrailParticle::draw(glm::fvec2 cameraOffset, const GameState &) {
-    const glm::fvec2 VIEW_POS = position - cameraOffset;
-
+void TrailParticle::draw(const GameState &) {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
     glPushMatrix();
-    glTranslatef(VIEW_POS.x, VIEW_POS.y, -0.1f);
+    glTranslatef(position.x, position.y, -0.1f);
     glScalef(size, size, 1.0f);
 
     // Draw a glowing circle with brighter center

--- a/2_2d_animation/src/base.hpp
+++ b/2_2d_animation/src/base.hpp
@@ -38,7 +38,7 @@ BulletPattern getCurrentBulletPattern(int currentTime);
 struct Drawable {
     /// @brief Draw the object with a given camera camera_offset
     /// @param camera_offset The camera offset to apply
-    virtual void draw(glm::vec2 camera_offset, const GameState &gameState) = 0;
+    virtual void draw(const GameState &gameState) = 0;
     virtual ~Drawable() = default;
 };
 
@@ -62,7 +62,7 @@ struct TrailParticle : Drawable, Updatable {
 
     TrailParticle(glm::fvec2 pos, glm::fvec2 vel, float sz, glm::fvec3 col, int currentTime);
     bool update(int currentTime, GameState &) override;
-    void draw(glm::fvec2 cameraOffset, const GameState &) override;
+    void draw(const GameState &) override;
 };
 struct EnemyBullet : Updatable, Drawable, Collidable {
     glm::fvec2 initialDirection;
@@ -79,7 +79,7 @@ struct EnemyBullet : Updatable, Drawable, Collidable {
                 int initialTime, std::function<float(int, float)> posFunc);
 
     bool update(int currentTime, GameState &gameState) override;
-    void draw(glm::fvec2 cameraOffset, const GameState &gameState) override;
+    void draw(const GameState &gameState) override;
     CollisionShape getShape() const override;
 };
 struct PlayerBullet : Updatable, Drawable, Collidable {
@@ -91,7 +91,7 @@ struct PlayerBullet : Updatable, Drawable, Collidable {
     PlayerBullet(glm::fvec2 initialPosition, float speed, int initialTime);
 
     bool update(int currentTime, GameState &gameState) override;
-    void draw(glm::fvec2 cameraOffset, const GameState &gameState) override;
+    void draw(const GameState &gameState) override;
     CollisionShape getShape() const override;
 };
 struct PlayerFragment : Drawable, Updatable {
@@ -107,7 +107,7 @@ struct PlayerFragment : Drawable, Updatable {
                    glm::fvec3 col);
 
     bool update(int deltaTime, GameState &) override;
-    void draw(glm::fvec2 cameraOffset, const GameState &) override;
+    void draw(const GameState &) override;
 };
 struct Player : Updatable, Drawable, Collidable {
     glm::fvec2 currentPosition;
@@ -128,7 +128,7 @@ struct Player : Updatable, Drawable, Collidable {
     void startDeathAnimation(int currentTime);
     void tryAttack();
     bool update(int currentTime, GameState &gameState) override;
-    void draw(glm::fvec2 cameraOffset, const GameState &gameState) override;
+    void draw(const GameState &gameState) override;
     void move(glm::fvec2 deltaPosition);
     void takeDamage(int currentTime);
     CollisionShape getShape() const override;
@@ -170,7 +170,7 @@ struct BossFragment : Drawable, Updatable {
     BossFragment(glm::fvec2 pos, glm::fvec2 vel, float rot, float rotSpeed, float sz,
                  glm::fvec3 col);
     bool update(int deltaTime, GameState &) override;
-    void draw(glm::fvec2 cameraOffset, const GameState &) override;
+    void draw(const GameState &) override;
 };
 struct BossArm : Drawable {
     // 4개 관절 각도
@@ -192,7 +192,7 @@ struct BossArm : Drawable {
     void update(float time);
     void drawSegment(float length, float width, float brightness);
     void drawJoint(float size);
-    void draw(glm::fvec2 cameraOffset, const GameState &gameState) override;
+    void draw(const GameState &gameState) override;
 };
 struct Boss : Updatable, Drawable, Collidable {
     glm::fvec2 currentPosition;
@@ -214,7 +214,7 @@ struct Boss : Updatable, Drawable, Collidable {
     static void drawUnitOctagonFan(float z, const glm::vec4 &centerRGBA, const glm::vec4 &edgeRGBA);
     static void drawUnitSpikeTri(float rOuter, float rInner, float z, const glm::vec4 &innerRGBA,
                                  const glm::vec4 &tipRGBA);
-    void draw(glm::fvec2 cameraOffset, const GameState &gameState) override;
+    void draw(const GameState &gameState) override;
     CollisionShape getShape() const override;
 };
 
@@ -223,14 +223,14 @@ struct PlayerHealthBar : Drawable {
 
     PlayerHealthBar(glm::fvec2 drawPosition);
 
-    void draw(glm::fvec2 cameraOffset, const GameState &gameState) override;
+    void draw(const GameState &gameState) override;
 };
 struct BossHealthBar : Drawable {
     glm::fvec2 drawPosition;
 
     BossHealthBar(glm::fvec2 drawPosition);
 
-    void draw(glm::fvec2 cameraOffset, const GameState &gameState) override;
+    void draw(const GameState &gameState) override;
 };
 
 struct Star : Drawable, Updatable {
@@ -241,7 +241,7 @@ struct Star : Drawable, Updatable {
 
     Star(glm::fvec2 pos, float spd, float sz, float br);
     bool update(int deltaTime, GameState & /*gameState*/) override;
-    void draw(glm::fvec2 cameraOffset, const GameState &) override;
+    void draw(const GameState &) override;
 };
 struct Background : Drawable, Updatable {
     std::vector<Star> stars;
@@ -251,7 +251,7 @@ struct Background : Drawable, Updatable {
 
     void initializeStars();
     bool update(int currentTime, GameState &gameState) override;
-    void draw(glm::fvec2 cameraOffset, const GameState &gameState) override;
+    void draw(const GameState &gameState) override;
 };
 
 struct GameState {

--- a/2_2d_animation/src/base.hpp
+++ b/2_2d_animation/src/base.hpp
@@ -51,7 +51,6 @@ struct Updatable {
     virtual ~Updatable() = default;
 };
 
-struct BossMove;
 struct TrailParticle : Drawable, Updatable {
     glm::fvec2 position;
     glm::fvec2 velocity;
@@ -197,6 +196,7 @@ struct BossArm : Drawable {
 struct Boss : Updatable, Drawable, Collidable {
     glm::fvec2 currentPosition;
     BossMove currentMove;
+    int bossId;
     int coolTime = 0;
     int coolTimePeriod = 500;
     bool isDying = false;
@@ -261,7 +261,8 @@ struct GameState {
     const int MAX_BOSS_HEALTH;
     int playerHealth;
     int bossHealth;
-    glm::fvec2 cameraOffset;
+    glm::fvec2 cameraShakeOffset;
+    glm::fvec2 cameraBaseOffset;
     bool konamiUsed = false;
 
     Player playerObject;

--- a/2_2d_animation/src/main.cpp
+++ b/2_2d_animation/src/main.cpp
@@ -8,9 +8,9 @@ std::uniform_real_distribution<float> dist(0.0f, 1.0f);
 GameState::GameState(int h, int bh)
     : MAX_PLAYER_HEALTH(h), MAX_BOSS_HEALTH(bh), playerHealth(h), bossHealth(bh),
       cameraBaseOffset(0.0f, 0.0f), cameraShakeOffset(0.0f, 0.0f),
-      playerObject(glm::fvec2(0.0f, -0.8f)),
-      bossObject1(glm::fvec2(0.5f, 0.6f), 1), bossObject2(glm::fvec2(-0.5f, 0.6f), 2),
-      bossHealthBarObject(glm::fvec2(0.0f, 0.0f)), heartsObject(glm::fvec2(0.0f, 0.0f)) {}
+      playerObject(glm::fvec2(0.0f, -0.8f)), bossObject1(glm::fvec2(0.5f, 0.6f), 1),
+      bossObject2(glm::fvec2(-0.5f, 0.6f), 2), bossHealthBarObject(glm::fvec2(0.0f, 0.0f)),
+      heartsObject(glm::fvec2(0.0f, 0.0f)) {}
 
 float playerSpeedBase = 0.00065f; // f/ms
 bool isCameraShake = false;

--- a/2_2d_animation/src/main.cpp
+++ b/2_2d_animation/src/main.cpp
@@ -7,11 +7,12 @@ std::uniform_real_distribution<float> dist(0.0f, 1.0f);
 
 GameState::GameState(int h, int bh)
     : MAX_PLAYER_HEALTH(h), MAX_BOSS_HEALTH(bh), playerHealth(h), bossHealth(bh),
-      cameraOffset(0.0f, 0.0f), playerObject(glm::fvec2(0.0f, -0.8f)),
+      cameraBaseOffset(0.0f, 0.0f), cameraShakeOffset(0.0f, 0.0f),
+      playerObject(glm::fvec2(0.0f, -0.8f)),
       bossObject1(glm::fvec2(0.5f, 0.6f), 1), bossObject2(glm::fvec2(-0.5f, 0.6f), 2),
       bossHealthBarObject(glm::fvec2(0.0f, 0.0f)), heartsObject(glm::fvec2(0.0f, 0.0f)) {}
 
-float playerSpeedBase = 0.0005f; // f/ms
+float playerSpeedBase = 0.00065f; // f/ms
 bool isCameraShake = false;
 int cameraShakeStartTime = 0;
 bool keyStates[256] = {false};
@@ -65,11 +66,13 @@ void keyboardUp(unsigned char key, int /*x*/, int /*y*/) { keyStates[key] = fals
 void display() {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
+    glm::fvec2 &cbo = gameState.cameraBaseOffset;
+
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    glOrtho(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0);
+    glOrtho(-1.0 + cbo.x, 1.0 + cbo.x, -1.0 + cbo.y, 1.0 + cbo.y, -1.0, 1.0);
     glPushMatrix();
-    glTranslatef(-gameState.cameraOffset.x, -gameState.cameraOffset.y, 0.0f);
+    glTranslatef(-gameState.cameraShakeOffset.x, -gameState.cameraShakeOffset.y, 0.0f);
     glMatrixMode(GL_MODELVIEW);
 
     gameState.backgroundObject.draw(gameState);
@@ -150,7 +153,7 @@ void timer(int) {
         gameState.bossObject2.currentMove = bossMoveData2.value();
     }
     if (isCameraShake) {
-        gameState.cameraOffset = cameraShake(now);
+        gameState.cameraShakeOffset = cameraShake(now);
     }
 
     int dt = now - lastMs;

--- a/2_2d_animation/src/main.cpp
+++ b/2_2d_animation/src/main.cpp
@@ -68,27 +68,33 @@ void display() {
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     glOrtho(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0);
+    glPushMatrix();
+    glTranslatef(-gameState.cameraOffset.x, -gameState.cameraOffset.y, 0.0f);
     glMatrixMode(GL_MODELVIEW);
 
-    gameState.backgroundObject.draw(gameState.cameraOffset, gameState);
+    gameState.backgroundObject.draw(gameState);
 
     // Draw trail particles before bullets for better visual effect
     for (auto &particle : gameState.trailParticles) {
-        particle.draw(gameState.cameraOffset, gameState);
+        particle.draw(gameState);
     }
 
     for (auto &object : gameState.enemyBulletObjects) {
-        object.draw(gameState.cameraOffset, gameState);
+        object.draw(gameState);
     }
     for (auto &object : gameState.playerBulletObjects) {
-        object.draw(gameState.cameraOffset, gameState);
+        object.draw(gameState);
     }
-    gameState.playerObject.draw(gameState.cameraOffset, gameState);
-    gameState.bossObject1.draw(gameState.cameraOffset, gameState);
-    gameState.bossObject2.draw(gameState.cameraOffset, gameState);
+    gameState.playerObject.draw(gameState);
+    gameState.bossObject1.draw(gameState);
+    gameState.bossObject2.draw(gameState);
 
-    gameState.bossHealthBarObject.draw(gameState.cameraOffset, gameState);
-    gameState.heartsObject.draw(gameState.cameraOffset, gameState);
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glMatrixMode(GL_MODELVIEW);
+
+    gameState.bossHealthBarObject.draw(gameState);
+    gameState.heartsObject.draw(gameState);
 
     glutSwapBuffers();
     glutPostRedisplay();


### PR DESCRIPTION
### (한 거 요약)
* cameraOffset -> cameraShakeOffset
* (new) cameraBaseOffset
* 월드 확장.
* 눈에 보이는 월드보더 생성.
* 보스 이동 패턴 조정. (두 보스가 움직이는 속도, 범위, 이동 주기를 다르게 설정함)
* 보스 총알 패턴 조정.
* 메이플식 카메라 무빙.
* 이동속도 상향.
* 보스 id 부여. (이제 약간의 색상 변경으로 구분 가능.)

### (생각)
* 보스가 화면 밖이면 어딨는지 화살표로 보여주기 ㅇㄸ?
* 진짜 메이플식 카메라 무빙(특정 범위 벗어나면 천천히 범위 안으로 이동하기)
* 깰 수 있는지 체크 해봐야 됨.