### PR TITLE
feat: ocean mesh vertex

### DIFF
--- a/final_project/src/main.cpp
+++ b/final_project/src/main.cpp
@@ -58,28 +58,78 @@ float lastFrameTime = 0.0f;
 std::vector<float> vertices;
 
 GLuint gPointVAO = 0;
+GLuint gPointEBO = 0;
 GLuint gPointProgram = 0;
+
+// Camera state - shoreline view
+glm::vec3 cameraPos = glm::vec3(0.0f, 0.2f, 1.5f);  // A bit higher and further back
+glm::vec3 cameraTarget = glm::vec3(0.0f, 0.0f, 0.0f);  // Look at center of ocean
+glm::vec3 cameraUp = glm::vec3(0.0f, 1.0f, 0.0f);
+float cameraSpeed = 1.0f;
 
 void initPointDraw() {
     glGenVertexArrays(1, &gPointVAO);
     glBindVertexArray(gPointVAO);
+
+    // Create index buffer for high-resolution triangle mesh
+    std::vector<GLuint> indices;
+    for (int y = 0; y < RENDER_GRID_SIZE - 1; y++) {
+        for (int x = 0; x < RENDER_GRID_SIZE - 1; x++) {
+            int topLeft = y * RENDER_GRID_SIZE + x;
+            int topRight = topLeft + 1;
+            int bottomLeft = (y + 1) * RENDER_GRID_SIZE + x;
+            int bottomRight = bottomLeft + 1;
+
+            // First triangle
+            indices.push_back(topLeft);
+            indices.push_back(bottomLeft);
+            indices.push_back(topRight);
+
+            // Second triangle
+            indices.push_back(topRight);
+            indices.push_back(bottomLeft);
+            indices.push_back(bottomRight);
+        }
+    }
+
+    glGenBuffers(1, &gPointEBO);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, gPointEBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(GLuint), indices.data(), GL_STATIC_DRAW);
+
     gPointProgram = createPointShaderProgram();
     glBindVertexArray(0);
 }
 
-void drawIFFTPoints() {
+void drawIFFTPoints(float currentTime, int windowWidth, int windowHeight) {
     glUseProgram(gPointProgram);
     glBindVertexArray(gPointVAO);
 
     // SSBO 바인딩 (vertex shader에서 binding = 1)
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, gCurrSSBO);
 
-    GLint locGrid = glGetUniformLocation(gPointProgram, "uGridSize");
+    // Grid and scale uniforms
+    GLint locIFFTGrid = glGetUniformLocation(gPointProgram, "uIFFTGridSize");
+    GLint locRenderGrid = glGetUniformLocation(gPointProgram, "uRenderGridSize");
     GLint locScale = glGetUniformLocation(gPointProgram, "uHeightScale");
-    glUniform1i(locGrid, GRID_SIZE);
-    glUniform1f(locScale, 1.0f);
+    glUniform1i(locIFFTGrid, GRID_SIZE);
+    glUniform1i(locRenderGrid, RENDER_GRID_SIZE);
+    glUniform1f(locScale, HEIGHT_SCALE);
 
-    glDrawArrays(GL_POINTS, 0, GRID_SIZE * GRID_SIZE);
+    // View matrix (looking at ocean from angle)
+    glm::mat4 view = glm::lookAt(cameraPos, cameraTarget, cameraUp);
+    GLint locView = glGetUniformLocation(gPointProgram, "uView");
+    glUniformMatrix4fv(locView, 1, GL_FALSE, &view[0][0]);
+
+    // Projection matrix - narrower FOV to hide edges
+    float aspect = (float)windowWidth / (float)windowHeight;
+    glm::mat4 projection = glm::perspective(glm::radians(30.0f), aspect, 0.1f, 100.0f);
+    GLint locProjection = glGetUniformLocation(gPointProgram, "uProjection");
+    glUniformMatrix4fv(locProjection, 1, GL_FALSE, &projection[0][0]);
+
+    // Draw filled triangles
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    int numIndices = (RENDER_GRID_SIZE - 1) * (RENDER_GRID_SIZE - 1) * 6;
+    glDrawElements(GL_TRIANGLES, numIndices, GL_UNSIGNED_INT, 0);
 
     glBindVertexArray(0);
     glUseProgram(0);
@@ -103,6 +153,7 @@ void cleanup() {
     glDeleteProgram(shaderProgram);
 
     glDeleteVertexArrays(1, &gPointVAO);
+    glDeleteBuffers(1, &gPointEBO);
     glDeleteProgram(gPointProgram);
 
     glDeleteBuffers(1, &gBaseSSBO);
@@ -172,9 +223,13 @@ int main(int argc, char **argv) {
         // GPU에서 iFFT 돌려서 gCurrSSBO 채우기
         runIFFTCompute(currentTime);
 
+        // Get window size for aspect ratio
+        int windowWidth, windowHeight;
+        glfwGetFramebufferSize(window, &windowWidth, &windowHeight);
+
         // 화면 클리어 + 렌더 + 버퍼 스왑
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-        drawIFFTPoints();
+        drawIFFTPoints(currentTime, windowWidth, windowHeight);
         glfwSwapBuffers(window);
 
         glfwPollEvents();

--- a/final_project/src/main.cpp
+++ b/final_project/src/main.cpp
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
 #endif
 
     // 윈도우 생성
-    GLFWwindow* window = glfwCreateWindow(800, 600, "CSED451 Final Project", nullptr, nullptr);
+    GLFWwindow* window = glfwCreateWindow(1600, 1200, "CSED451 Final Project", nullptr, nullptr);
     if (!window) {
         std::cerr << "Failed to create GLFW window\n";
         glfwTerminate();

--- a/final_project/src/shaders/ocean.frag
+++ b/final_project/src/shaders/ocean.frag
@@ -4,16 +4,20 @@ in float vHeight;
 out vec4 FragColor;
 
 // 높이 값을 컬러로 매핑
-vec3 heightToColor(float t) {
-    float value = (t * 0.5) + 0.5; // -1~1 -> 0~1 (대충)
+vec3 heightToColor(float h) {
+    // Normalize height to 0~1 range based on expected wave amplitude
+    // Adjust the divisor based on actual wave height range
+    float value = clamp((h / 2.0) + 0.5, 0.0, 1.0);
 
-    vec3 low  = vec3(0.0, 0.0, 1.0);  // 파랑
-    vec3 mid  = vec3(0.0, 1.0, 0.0);  // 초록
-    vec3 high = vec3(1.0, 0.0, 0.0);  // 빨강
+    vec3 low  = vec3(0.0, 0.2, 0.5);  // 어두운 파랑 (낮음)
+    vec3 mid  = vec3(0.0, 0.6, 0.8);  // 밝은 파랑 (중간)
+    vec3 high = vec3(0.8, 0.95, 1.0); // 거품 흰색 (높음)
 
-    vec3 color = mix(low, mid, value * 2.0);
-    if (value > 0.5) {
-        color = mix(mid, high, (value - 0.5) * 2.0);
+    vec3 color;
+    if (value < 0.5) {
+        color = mix(low, mid, value * 2.0);
+    } else {
+        color = mix(mid, high, (value - 0.5) * 1.0);
     }
     return color;
 }

--- a/final_project/src/shaders/ocean.vert
+++ b/final_project/src/shaders/ocean.vert
@@ -9,37 +9,87 @@ layout(std430, binding = 1) readonly buffer HeightData {
     Complex height[];
 };
 
-uniform int uGridSize;
+uniform int uIFFTGridSize;     // IFFT resolution (e.g., 32)
+uniform int uRenderGridSize;   // Render mesh resolution (e.g., 256)
 uniform float uHeightScale;
+uniform mat4 uView;
+uniform mat4 uProjection;
 
 out float vHeight;
 
+// Cubic interpolation weight function (Catmull-Rom)
+float cubicWeight(float x) {
+    float ax = abs(x);
+    if (ax < 1.0) {
+        return 1.0 - 2.5*ax*ax + 1.5*ax*ax*ax;
+    } else if (ax < 2.0) {
+        return 2.0 - 4.0*ax + 2.5*ax*ax - 0.5*ax*ax*ax;
+    }
+    return 0.0;
+}
+
+// Sample height from IFFT grid with wrapping
+float sampleHeight(int gx, int gy) {
+    int N = uIFFTGridSize;
+    // Wrap coordinates for seamless tiling
+    gx = (gx + N) % N;
+    gy = (gy + N) % N;
+    int idx = gy * N + gx;
+    return height[idx].re;
+}
+
+// Bicubic interpolation of height field
+float bicubicInterpolate(float u, float v) {
+    int N = uIFFTGridSize;
+
+    // Convert normalized coords to grid space
+    float gx = u * float(N);
+    float gy = v * float(N);
+
+    // Integer grid cell
+    int gxi = int(floor(gx));
+    int gyi = int(floor(gy));
+
+    // Fractional part within cell
+    float fx = gx - float(gxi);
+    float fy = gy - float(gyi);
+
+    // Sample 4x4 neighborhood and apply bicubic weights
+    float h = 0.0;
+    for (int dy = -1; dy <= 2; dy++) {
+        for (int dx = -1; dx <= 2; dx++) {
+            float wx = cubicWeight(float(dx) - fx);
+            float wy = cubicWeight(float(dy) - fy);
+            h += sampleHeight(gxi + dx, gyi + dy) * wx * wy;
+        }
+    }
+
+    return h;
+}
+
 void main() {
-    int N   = uGridSize;
-    int idx = gl_VertexID;   // 0 .. N*N-1
+    int renderN = uRenderGridSize;
+    int idx = gl_VertexID;
 
-    int x = idx % N;
-    int y = idx / N;
+    int x = idx % renderN;
+    int y = idx / renderN;
 
-    // [-1, 1] 범위로 정규화한 평면 좌표 (XY plane)
-    float fx = (float(x) / float(N - 1)) * 2.0 - 1.0;
-    float fy = (float(y) / float(N - 1)) * 2.0 - 1.0;
+    // Normalized coordinates [0, 1] in the mesh
+    float u = float(x) / float(renderN - 1);
+    float v = float(y) / float(renderN - 1);
 
-    float h = height[idx].re * uHeightScale;
+    // World space position before height displacement
+    float fx = u * 4.0 - 2.0;  // [-2, 2]
+    float fz = v * 4.0 - 2.0;  // [-2, 2]
 
-    // 예전이랑 동일: 평면은 XY, 높이는 Z
-    vec3 pos = vec3(fx, fy, h);
+    // Sample height using bicubic interpolation
+    float h = bicubicInterpolate(u, v) * uHeightScale;
 
-    float angle = -1.2; // ~70도
-    mat4 rotation = mat4(
-        1.0, 0.0,        0.0,        0.0,
-        0.0, cos(angle), -sin(angle), 0.0,
-        0.0, sin(angle),  cos(angle), 0.0,
-        0.0, 0.0,        0.0,        1.0
-    );
+    // 평면은 XZ (horizontal), 높이는 Y (up)
+    vec3 pos = vec3(fx, h, fz);
 
-    gl_Position = rotation * vec4(pos, 1.0);
-    gl_PointSize = 3.0;
+    // Apply view and projection matrices
+    gl_Position = uProjection * uView * vec4(pos, 1.0);
 
     vHeight = h;
 }

--- a/final_project/src/utils.hpp
+++ b/final_project/src/utils.hpp
@@ -30,7 +30,9 @@ struct ThreeDObj {
     void draw(const std::string objName);
 };
 
-#define GRID_SIZE 32
+const unsigned int GRID_SIZE = 32;  // IFFT resolution
+const unsigned int RENDER_GRID_SIZE = GRID_SIZE * 8;  // High-res rendering mesh
+const float HEIGHT_SCALE = 2.0f;
 
 extern std::complex<float> currentHeight[GRID_SIZE][GRID_SIZE];
 void initSpectra();


### PR DESCRIPTION
32x32 그리드에서 시행한 IFFT를 기반으로 256x256 매쉬의 정점을 계산함

각 정점은 가장 가까운 16개의 IFFT 값을 [Catmull-Rom spline 보간](https://en.wikipedia.org/wiki/Centripetal_Catmull%E2%80%93Rom_spline)으로 조정하여 파도가 자연스러운 곡선 모양을 가지도록 하였음

시점은 Perspective View로 전환함

-------

보간 전 IFFT 값 1024개를 그대로 렌더링하였을 때 / 보간된 매쉬 그리드를 위에서 바라본 모습

<img width="49%" height="1258" alt="image" src="https://github.com/user-attachments/assets/b8552b89-0236-499a-ba81-38fc64306418" />
<img width="49%" height="1258" alt="image" src="https://github.com/user-attachments/assets/b137cd1e-b96d-40e7-aae0-471b68b3129a" />

최종적으로 Perspective View로 바라본 보간 매쉬 모습

<img width="100%" height="1296" alt="image" src="https://github.com/user-attachments/assets/fe0ac4f5-dd3c-4f08-9983-77a9ad87be8a" />

